### PR TITLE
Inject runTest interface and suite scripts into d1 generated component

### DIFF
--- a/scripts/src/Plugin.ts
+++ b/scripts/src/Plugin.ts
@@ -4,8 +4,10 @@ import { SourceNode } from 'source-map';
 class BsBenchPlugin implements CompilerPlugin {
     name = 'bsbench';
 
-    // Maps "<suiteName>" -> generated leaf component name, populated in beforePrepareProgram
+    // Maps suiteName -> generated leaf component name, populated in afterProgramValidate
     private generatedComponentNames = new Map<string, string>();
+    // XML dest paths of all generated d1 (root) components, for injectSuiteImports
+    private generatedRootXmlPaths: string[] = [];
 
     afterProgramCreate(event: AfterProgramCreateEvent) {
     }
@@ -77,6 +79,7 @@ class BsBenchPlugin implements CompilerPlugin {
 
     afterProgramValidate(event: AfterProgramValidateEvent) {
         this.generatedComponentNames.clear();
+        this.generatedRootXmlPaths = [];
         for (const file of Object.values(event.program.files)) {
             for (const suite of this.findSuites(file)) {
                 const setupFunction = this.findFunction(suite, 'setup');
@@ -99,8 +102,18 @@ class BsBenchPlugin implements CompilerPlugin {
                 let parentName = componentExtends;
                 for (let i = 1; i <= depth; i++) {
                     const componentName = `__bsbench_${slug}_d${i}`;
-                    const xml = `<component name="${componentName}" extends="${parentName}">\n</component>\n`;
-                    event.program.setFile(`components/bsbench_generated/${componentName}.xml`, xml);
+                    const xmlPath = `components/bsbench_generated/${componentName}.xml`;
+                    if (i === 1) {
+                        // d1 gets the runTest interface + companion script; suite scripts injected later
+                        const xml = `<component name="${componentName}" extends="${parentName}">\n    <script type="text/brightscript" uri="${componentName}.brs" />\n    <interface>\n        <function name="runTest" />\n    </interface>\n</component>\n`;
+                        const bs = `import "pkg:/source/bsbench.bs"\n\nfunction runTest(suiteName as string, testName as string, thread as string, variant as roAssociativeArray)\n    return promises.try(function(suiteName, testName, thread, variant)\n        info = bsbench.getTestInfo(suiteName, testName)\n        return bsbench.runTest(info.test, variant, thread, suiteName)\n    end function, [suiteName, testName, thread, variant])\nend function\n`;
+                        event.program.setFile(xmlPath, xml);
+                        event.program.setFile(`components/bsbench_generated/${componentName}.bs`, bs);
+                        this.generatedRootXmlPaths.push(xmlPath);
+                    } else {
+                        const xml = `<component name="${componentName}" extends="${parentName}">\n</component>\n`;
+                        event.program.setFile(xmlPath, xml);
+                    }
                     parentName = componentName;
                 }
                 this.generatedComponentNames.set(suite.name, parentName);
@@ -137,7 +150,7 @@ class BsBenchPlugin implements CompilerPlugin {
     }
 
     private injectSuiteImports(event: BeforeBuildProgramEvent, allSuites: Suite[]) {
-        for (const xmlPath of ['components/MainScene.xml', 'components/TestTask.xml']) {
+        for (const xmlPath of ['components/MainScene.xml', 'components/TestTask.xml', ...this.generatedRootXmlPaths]) {
             const xmlFile = event.program.getFile<XmlFile>(xmlPath);
             if (!isXmlFile(xmlFile)) {
                 continue;

--- a/scripts/src/Plugin.ts
+++ b/scripts/src/Plugin.ts
@@ -104,11 +104,15 @@ class BsBenchPlugin implements CompilerPlugin {
                     const componentName = `__bsbench_${slug}_d${i}`;
                     const xmlPath = `components/bsbench_generated/${componentName}.xml`;
                     if (i === 1) {
-                        // d1 gets the runTest interface + companion script; suite scripts injected later
-                        const xml = `<component name="${componentName}" extends="${parentName}">\n    <script type="text/brightscript" uri="${componentName}.brs" />\n    <interface>\n        <function name="runTest" />\n    </interface>\n</component>\n`;
-                        const bs = `import "pkg:/source/bsbench.bs"\n\nfunction runTest(suiteName as string, testName as string, thread as string, variant as roAssociativeArray)\n    return promises.try(function(suiteName, testName, thread, variant)\n        info = bsbench.getTestInfo(suiteName, testName)\n        return bsbench.runTest(info.test, variant, thread, suiteName)\n    end function, [suiteName, testName, thread, variant])\nend function\n`;
+                        // d1 gets the runTest interface + companion script; suite scripts injected later by injectSuiteImports.
+                        const xml = `
+                            <component name="${componentName}" extends="${parentName}">
+                                <script type="text/brightscript" uri="pkg:/source/bsbench.bs" />
+                                <interface>
+                                    <function name="runRenderThreadTest" />
+                                </interface>
+                            </component>`.trim()
                         event.program.setFile(xmlPath, xml);
-                        event.program.setFile(`components/bsbench_generated/${componentName}.bs`, bs);
                         this.generatedRootXmlPaths.push(xmlPath);
                     } else {
                         const xml = `<component name="${componentName}" extends="${parentName}">\n</component>\n`;
@@ -167,7 +171,7 @@ class BsBenchPlugin implements CompilerPlugin {
             }
             let insertIndex = lastScriptIdx + 1;
             for (const suite of allSuites) {
-                const uri = 'pkg:/' + suite.file.destPath.replace(/\.bs$/, '.brs');
+                const uri = 'pkg:/' + suite.file.destPath.replace(/\.bs$/, '.brs').replace(/\\/g, '/');
                 if (alreadyImported.has(uri)) {
                     continue;
                 }
@@ -202,7 +206,7 @@ class BsBenchPlugin implements CompilerPlugin {
         let atOnlySuites = allSuites.filter(x => x.namespaceStatement.annotations?.find(x => x.name.toLowerCase() === 'only'));
         let suitesToRun = atOnlySuites.length > 0 ? atOnlySuites
             : filterPatterns.length > 0 ? allSuites.filter(x => filterPatterns.some(p => new RegExp(p, 'i').test(x.name)))
-            : allSuites;
+                : allSuites;
 
         if (atOnlySuites.length > 0) {
             console.log(`[bsbench] Running ${suitesToRun.length} of ${allSuites.length} suites (@only):\n${suitesToRun.map(x => `  - ${x.name}`).join('\n')}`);

--- a/src/components/MainScene.bs
+++ b/src/components/MainScene.bs
@@ -2,11 +2,3 @@ import "pkg:/source/bsbench.bs"
 
 sub init()
 end sub
-
-'Run a specific test from a suite
-function runTest(suiteName as string, testName as string, thread as string, variant as roAssociativeArray)
-    return promises.try(function(suiteName, testName, thread, variant)
-        info = bsbench.getTestInfo(suiteName, testName)
-        return bsbench.runTest(info.test, variant, thread, suiteName)
-    end function, [suiteName, testName, thread, variant])
-end function

--- a/src/components/MainScene.xml
+++ b/src/components/MainScene.xml
@@ -1,6 +1,6 @@
 <component name="MainScene" extends="Scene">
     <script type="text/brightscript" uri="MainScene.bs" />
     <interface>
-        <function name="runTest" />
+        <function name="runRenderThreadTest" />
     </interface>
 </component>

--- a/src/source/benchmarks/MTopHoisting.bs
+++ b/src/source/benchmarks/MTopHoisting.bs
@@ -1,9 +1,11 @@
-@suite({ componentExtends: "Group", depth: 5 })
+@suite({ componentExtends: "Group", depth: 5,  })
 namespace MTopHoisting
     sub setup()
+        ' print "setup for mtop hoisting"
         if m.top = invalid
             m.top = createObject("roSGNode", "Group") as dynamic
         end if
+        print "MTopHoisting: m.top subtype = " + m.top.subtype()
         m.top.update({
             thing1: "alpha"
             thing2: "beta"
@@ -16,6 +18,7 @@ namespace MTopHoisting
 
     @test("m.top each time")
     sub _()
+        ' print "mtop hoisting iteration"
         result = m.top.thing1
         result = m.top.thing2
         result = m.top.thing3

--- a/src/source/bsbench.bs
+++ b/src/source/bsbench.bs
@@ -64,45 +64,98 @@ namespace bsbench
         end function, {})
     end function
 
+    function getSuiteNode(suite as BenchmarkSuite)
+        mainScene = bsbench.getMainScene()
+        return mainScene
+        if promises.internal.isNonEmptyString(suite.componentName) then
+            if m.suiteNodeCache = invalid then m.suiteNodeCache = {}
+            if m.suiteNodeCache[suite.componentName] <> invalid then
+                suiteNode = CreateObject("roSGNode", suite.componentName)
+                print "created suite component: " + suite.componentName suiteNode
+                'append to the main scene
+                mainScene.appendChild(suiteNode)
+                m.suiteNodeCache[suite.componentName] = suiteNode
+            end if
+
+            return m.suiteNodeCache[suite.componentName]
+        else
+            return mainScene
+        end if
+    end function
+
+    function freeSuiteNode(suite as BenchmarkSuite)
+        if promises.internal.isNonEmptyString(suite.componentName) and m.suiteNodeCache <> invalid and m.suiteNodeCache[suite.componentName] <> invalid
+            suiteNode = m.suiteNodeCache[suite.componentName]
+            if suiteNode <> invalid
+                print "freeing suite component: " + suite.componentName suiteNode
+                mainScene = bsbench.getMainScene()
+                mainScene.removeChild(suiteNode)
+                m.suiteNodeCache[suite.componentName] = invalid
+            end if
+        end if
+    end function
+
     function runSuite(suite as BenchmarkSuite) as object
-        ' for each thread: run all variants of all tests, print intermediary, accumulate
-        p = promises.onThen(bsbench.promiseForEach(suite.allowedThreads, function(thread, ctx) as object
-            print ""
-            print `${ctx.suite.name} [${thread} thread]`
-            return promises.onThen(bsbench.promiseForEach(ctx.suite.variants, function(variant, ctx) as object
-                return bsbench.promiseForEach(ctx.suite.tests, function(test, ctx) as object
-                    if ctx.thread = "render"
-                        mainScene = bsbench.getMainScene()
-                        return mainScene@.runTest(ctx.suite.name, test.name, ctx.thread, ctx.variant)
-                    else if ctx.thread = "task"
-                        testTask = bsbench.getTestTask()
-                        return testTask@.runTest(ctx.suite.name, test.name, ctx.thread, ctx.variant)
-                    else
-                        return bsbench.runTest(test, ctx.variant, ctx.thread, ctx.suite.name)
-                    end if
-                end function, { variant: ctx.variant, thread: ctx.thread, suite: ctx.suite })
-            end function, { suite: ctx.suite, thread: thread }), function(variantResults, ctx) as object
-                ' variantResults is array of arrays (one per variant, each containing BenchmarkResults)
-                threadResults = []
-                for each vr in variantResults
-                    for each r in vr
-                        if r <> invalid then threadResults.push(r)
-                    end for
-                end for
-                if threadResults.count() > 0
-                    bsbench.printIntermediaryResults(ctx.suite.name, ctx.thread, threadResults)
-                end if
-                return promises.resolve(threadResults)
-            end function, { suite: ctx.suite, thread: thread })
-        end function, { suite: suite }), function(allThreadResults, ctx) as object
+        return promises.chain(promises.ensurePromise(0), {
+            suite: suite,
+            'ensure the suiteNode is created beofre any tests run, this way memory is identical across all tests
+            suiteNode: bsbench.getSuiteNode(suite)
+        }).then(function(_, ctx)
+            'run each suite thread, return the array of all thread results
+            return bsbench.promiseForEach(ctx.suite.allowedThreads, function(thread, ctx) as object
+                return bsbench.runSuiteThread(ctx.suite, thread)
+            end function, ctx)
+        end function).then(function(allThreadResults, ctx) as object
             ' allThreadResults is array of arrays (one per thread)
             bsbench.printFinalResults(ctx.suite, allThreadResults)
             return promises.resolve(allThreadResults)
-        end function, { suite: suite })
-        return promises.onCatch(p, function(error, ctx) as object
+        end function).catch(function(error, ctx) as object
             bsbench.printError(`suite "${ctx.suite.name}"`, error)
             return promises.resolve(invalid)
-        end function, { suite: suite })
+        end function).finally(function(ctx)
+            'regardless of success or failure, free the suite node to clean up memory before the next suite runs
+            freeSuiteNode(ctx.suite)
+        end function).toPromise()
+    end function
+
+    function runSuiteThread(suite, thread)
+        print ""
+        print `${suite.name} [${thread} thread]`
+
+        return promises.chain(promises.resolve(0), {
+            suite: suite,
+            thread: thread
+        }).then(function(_, ctx)
+            return bsbench.promiseForEach(ctx.suite.variants, function(variant, ctx) as object
+                return bsbench.runSuiteThreadVariant(ctx.suite, ctx.thread, variant)
+            end function, { variant: ctx.variant, thread: ctx.thread, suite: ctx.suite })
+        end function).then(function(variantResults, ctx) as object
+            ' variantResults is array of arrays (one per variant, each containing BenchmarkResults)
+            threadResults = []
+            for each vr in variantResults
+                for each r in vr
+                    if r <> invalid then threadResults.push(r)
+                end for
+            end for
+            if threadResults.count() > 0
+                bsbench.printIntermediaryResults(ctx.suite.name, ctx.thread, threadResults)
+            end if
+            return promises.resolve(threadResults)
+        end function).toPromise()
+    end function
+
+    function runSuiteThreadVariant(suite, thread, variant)
+        return bsbench.promiseForEach(suite.tests, function(test, ctx) as object
+            if ctx.thread = "render"
+                suiteNode = bsbench.getSuiteNode(ctx.suite)
+                return suiteNode@.runRenderThreadTest(ctx.suite.name, test.name, ctx.thread, ctx.variant)
+            else if ctx.thread = "task"
+                testTask = bsbench.getTestTask()
+                return testTask@.runTest(ctx.suite.name, test.name, ctx.thread, ctx.variant)
+            else
+                return bsbench.runTest(test, ctx.variant, ctx.thread, ctx.suite.name)
+            end if
+        end function, { suite: suite, thread: thread, variant: variant })
     end function
 
     function runTest(test as BenchmarkTest, variant as roAssociativeArray, thread as string, suiteName as string) as object
@@ -192,6 +245,8 @@ namespace bsbench
             return bsbench.calibrateCorrect(runResult, ctx, invalid, 0)
         end function).then(function(runResult, ctx) as object
             return promises.resolve(runResult.iterations)
+        end function).catch(function(error, ctx)
+            print error, ctx
         end function).toPromise()
     end function
 
@@ -643,3 +698,13 @@ interface CalibrationRun
     iterationsPerMicrosecond as double
     iterationsForTargetDuration as longinteger
 end interface
+
+' Callfunc entry point for running a benchmark test on the render thread.
+' Declared in the <interface> of MainScene and generated component chains
+' (from @suite componentExtends+depth). Top-level so callfunc can find it by name directly.
+function runRenderThreadTest(suiteName as string, testName as string, thread as string, variant as roAssociativeArray)
+    return promises.try(function(suiteName, testName, thread, variant)
+        info = bsbench.getTestInfo(suiteName, testName)
+        return bsbench.runTest(info.test, variant, thread, suiteName)
+    end function, [suiteName, testName, thread, variant])
+end function

--- a/src/source/bsbench.bs
+++ b/src/source/bsbench.bs
@@ -64,12 +64,15 @@ namespace bsbench
         end function, {})
     end function
 
+    ' Create a SGNode for the suite if it doesn't already exist, and return it.
+    ' This node will be cached until you call freeSuiteNode, which removes it from the scene and frees memory.
+    ' So it's safe to call this multiple times. But ideally you call this once before the entire suite to ensure
+    ' consistent memory usage and in the scene. If your suite doesn't specify a componentExtends+depth, this will just return the main scene.
     function getSuiteNode(suite as BenchmarkSuite)
         mainScene = bsbench.getMainScene()
-        return mainScene
         if promises.internal.isNonEmptyString(suite.componentName) then
             if m.suiteNodeCache = invalid then m.suiteNodeCache = {}
-            if m.suiteNodeCache[suite.componentName] <> invalid then
+            if m.suiteNodeCache[suite.componentName] = invalid then
                 suiteNode = CreateObject("roSGNode", suite.componentName)
                 print "created suite component: " + suite.componentName suiteNode
                 'append to the main scene
@@ -87,7 +90,6 @@ namespace bsbench
         if promises.internal.isNonEmptyString(suite.componentName) and m.suiteNodeCache <> invalid and m.suiteNodeCache[suite.componentName] <> invalid
             suiteNode = m.suiteNodeCache[suite.componentName]
             if suiteNode <> invalid
-                print "freeing suite component: " + suite.componentName suiteNode
                 mainScene = bsbench.getMainScene()
                 mainScene.removeChild(suiteNode)
                 m.suiteNodeCache[suite.componentName] = invalid


### PR DESCRIPTION
## Summary

- The `d1` (root) generated component now gets the full treatment: a companion `.bs` with the `runTest` callfunc implementation, the `runTest` interface declaration, and all suite script imports injected via `injectSuiteImports`
- Deeper components (`d2`…`dN`) inherit everything via SceneGraph component inheritance — no extra scripts needed
- Reworked component injection logic and fixed `getSuiteNode` so the suite node resolves correctly across the inheritance chain
- Sets up a future path for running benchmarks at each level of the inheritance chain, since every level has the full script context from d1

## Why d1, not the leaf

Injecting at d1 means every component in the chain inherits the scripts and interface naturally. If we later want to callfunc into d2, d3, etc. independently, they all already have what they need.

Fixes issues with #16 